### PR TITLE
Added moveable slots

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ dependencies {
     compile 'commons-io:commons-io:2.6'
     compile 'com.github.clubobsidian:wrappy:1.8.0'
     compile 'com.github.clubobsidian:trident:2.0.1'
-    compile 'com.github.clubobsidian:dynamicguiparser:2.4.1'
+    compile 'com.github.clubobsidian:dynamicguiparser:2.5.0'
     compile 'com.udojava:EvalEx:2.1'
     compile 'com.github.ClubObsidian:FuzzUtil:1.1.0'
     compile 'com.google.inject:guice:4.2.2'

--- a/src/main/java/com/clubobsidian/dynamicgui/DynamicGui.java
+++ b/src/main/java/com/clubobsidian/dynamicgui/DynamicGui.java
@@ -25,6 +25,7 @@ import com.clubobsidian.dynamicgui.entity.PlayerWrapper;
 import com.clubobsidian.dynamicgui.function.impl.AddPermissionFunction;
 import com.clubobsidian.dynamicgui.function.impl.CheckItemTypeInHandFunction;
 import com.clubobsidian.dynamicgui.function.impl.CheckLevelFunction;
+import com.clubobsidian.dynamicgui.function.impl.CheckMoveableFunction;
 import com.clubobsidian.dynamicgui.function.impl.CheckPlayerWorldFunction;
 import com.clubobsidian.dynamicgui.function.impl.ConsoleCmdFunction;
 import com.clubobsidian.dynamicgui.function.impl.GetGameRuleFunction;
@@ -327,6 +328,7 @@ public class DynamicGui  {
 		FunctionManager.get().addFunction(new SetAmountFunction("setamount"));
 		FunctionManager.get().addFunction(new SetNBTFunction("setnbt"));
 		FunctionManager.get().addFunction(new SetGlowFunction("setglow"));
+		FunctionManager.get().addFunction(new CheckMoveableFunction("checkmoveable"));
 		FunctionManager.get().addFunction(new SetMoveableFunction("setmoveable"));
 		FunctionManager.get().addFunction(new SetEnchantsFunction("setenchants"));
 		FunctionManager.get().addFunction(new SetCloseFunction("setclose"));

--- a/src/main/java/com/clubobsidian/dynamicgui/DynamicGui.java
+++ b/src/main/java/com/clubobsidian/dynamicgui/DynamicGui.java
@@ -51,6 +51,7 @@ import com.clubobsidian.dynamicgui.function.impl.SetEnchantsFunction;
 import com.clubobsidian.dynamicgui.function.impl.SetGameRuleFunction;
 import com.clubobsidian.dynamicgui.function.impl.SetGlowFunction;
 import com.clubobsidian.dynamicgui.function.impl.SetLoreFunction;
+import com.clubobsidian.dynamicgui.function.impl.SetMoveableFunction;
 import com.clubobsidian.dynamicgui.function.impl.SetNBTFunction;
 import com.clubobsidian.dynamicgui.function.impl.SetNameFunction;
 import com.clubobsidian.dynamicgui.function.impl.SetTypeFunction;
@@ -275,7 +276,7 @@ public class DynamicGui  {
 	private void registerListeners() 
 	{
 		this.eventManager.registerEvents(new com.clubobsidian.dynamicgui.listener.EntityClickListener());
-		this.eventManager.registerEvents(new com.clubobsidian.dynamicgui.listener.InventoryClickListener());
+		this.eventManager.registerEvents(new com.clubobsidian.dynamicgui.listener.InventoryInteractListener());
 		this.eventManager.registerEvents(new com.clubobsidian.dynamicgui.listener.InventoryCloseListener());
 		this.eventManager.registerEvents(new com.clubobsidian.dynamicgui.listener.InventoryOpenListener());
 		this.eventManager.registerEvents(new com.clubobsidian.dynamicgui.listener.PlayerInteractListener());
@@ -326,6 +327,7 @@ public class DynamicGui  {
 		FunctionManager.get().addFunction(new SetAmountFunction("setamount"));
 		FunctionManager.get().addFunction(new SetNBTFunction("setnbt"));
 		FunctionManager.get().addFunction(new SetGlowFunction("setglow"));
+		FunctionManager.get().addFunction(new SetMoveableFunction("setmoveable"));
 		FunctionManager.get().addFunction(new SetEnchantsFunction("setenchants"));
 		FunctionManager.get().addFunction(new SetCloseFunction("setclose"));
 		FunctionManager.get().addFunction(new RemoveSlotFunction("removeslot"));

--- a/src/main/java/com/clubobsidian/dynamicgui/builder/SlotBuilder.java
+++ b/src/main/java/com/clubobsidian/dynamicgui/builder/SlotBuilder.java
@@ -34,6 +34,7 @@ public class SlotBuilder {
 	private String nbt;
 	private short data;
 	private boolean glow;
+	private boolean moveable;
 	private Boolean close;
 	private List<String> lore;
 	private List<EnchantmentWrapper> enchants;
@@ -84,6 +85,12 @@ public class SlotBuilder {
 	public SlotBuilder setGlow(boolean glow)
 	{
 		this.glow = glow;
+		return this;
+	}
+	
+	public SlotBuilder setMoveable(boolean moveable)
+	{
+		this.moveable = moveable;
 		return this;
 	}
 	
@@ -216,6 +223,6 @@ public class SlotBuilder {
 	
 	public Slot build()
 	{
-		return new Slot(this.index, this.amount,this.icon, this.name, this.nbt, this.data, this.glow, this.close, this.lore, this.enchants, this.functionTree, this.updateInterval, this.metadata);
+		return new Slot(this.index, this.amount,this.icon, this.name, this.nbt, this.data, this.glow, this.moveable, this.close, this.lore, this.enchants, this.functionTree, this.updateInterval, this.metadata);
 	}
 }

--- a/src/main/java/com/clubobsidian/dynamicgui/event/inventory/InventoryDragEvent.java
+++ b/src/main/java/com/clubobsidian/dynamicgui/event/inventory/InventoryDragEvent.java
@@ -1,0 +1,38 @@
+package com.clubobsidian.dynamicgui.event.inventory;
+
+import java.util.Map;
+
+import com.clubobsidian.dynamicgui.entity.PlayerWrapper;
+import com.clubobsidian.dynamicgui.event.InventoryEvent;
+import com.clubobsidian.dynamicgui.inventory.InventoryWrapper;
+import com.clubobsidian.dynamicgui.inventory.ItemStackWrapper;
+import com.clubobsidian.trident.Cancelable;
+
+public class InventoryDragEvent extends InventoryEvent implements Cancelable {
+
+	private Map<Integer, ItemStackWrapper<?>> slotItems;
+	private boolean cancelled;
+ 	public InventoryDragEvent(PlayerWrapper<?> playerWrapper, InventoryWrapper<?> inventoryWrapper, Map<Integer, ItemStackWrapper<?>> slotItems)
+	{
+		super(playerWrapper, inventoryWrapper);
+		this.slotItems = slotItems;
+		this.cancelled = false;
+	}
+
+ 	public Map<Integer, ItemStackWrapper<?>> getSlotItems()
+ 	{
+ 		return this.slotItems;
+ 	}
+ 	
+	@Override
+	public boolean isCanceled() 
+	{
+		return this.cancelled;
+	}
+
+	@Override
+	public void setCanceled(boolean cancel) 
+	{
+		this.cancelled = cancel;
+	}
+}

--- a/src/main/java/com/clubobsidian/dynamicgui/function/impl/CheckMoveableFunction.java
+++ b/src/main/java/com/clubobsidian/dynamicgui/function/impl/CheckMoveableFunction.java
@@ -1,0 +1,43 @@
+package com.clubobsidian.dynamicgui.function.impl;
+
+import com.clubobsidian.dynamicgui.entity.PlayerWrapper;
+import com.clubobsidian.dynamicgui.function.Function;
+import com.clubobsidian.dynamicgui.gui.FunctionOwner;
+import com.clubobsidian.dynamicgui.gui.Slot;
+
+public class CheckMoveableFunction extends Function {
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1037806025228025407L;
+
+	public CheckMoveableFunction(String name) 
+	{
+		super(name);
+	}
+
+	@Override
+	public boolean function(PlayerWrapper<?> playerWrapper) 
+	{
+		if(this.getData() == null)
+		{
+			return false;
+		}
+		
+		FunctionOwner owner = this.getOwner();
+		if(!(owner instanceof Slot))
+		{
+			return false;
+		}
+		
+		Slot slot = (Slot) owner;
+		Boolean value = Boolean.valueOf(this.getData());
+		if(value == null)
+		{
+			return false;
+		}
+		
+		return value.equals(slot.isMoveable());
+	}
+}

--- a/src/main/java/com/clubobsidian/dynamicgui/function/impl/SetMoveableFunction.java
+++ b/src/main/java/com/clubobsidian/dynamicgui/function/impl/SetMoveableFunction.java
@@ -5,8 +5,6 @@ import com.clubobsidian.dynamicgui.function.Function;
 import com.clubobsidian.dynamicgui.gui.FunctionOwner;
 import com.clubobsidian.dynamicgui.gui.Gui;
 import com.clubobsidian.dynamicgui.gui.Slot;
-import com.clubobsidian.dynamicgui.inventory.InventoryWrapper;
-import com.clubobsidian.dynamicgui.inventory.ItemStackWrapper;
 
 public class SetMoveableFunction extends Function {
 

--- a/src/main/java/com/clubobsidian/dynamicgui/function/impl/SetMoveableFunction.java
+++ b/src/main/java/com/clubobsidian/dynamicgui/function/impl/SetMoveableFunction.java
@@ -1,0 +1,50 @@
+package com.clubobsidian.dynamicgui.function.impl;
+
+import com.clubobsidian.dynamicgui.entity.PlayerWrapper;
+import com.clubobsidian.dynamicgui.function.Function;
+import com.clubobsidian.dynamicgui.gui.FunctionOwner;
+import com.clubobsidian.dynamicgui.gui.Gui;
+import com.clubobsidian.dynamicgui.gui.Slot;
+import com.clubobsidian.dynamicgui.inventory.InventoryWrapper;
+import com.clubobsidian.dynamicgui.inventory.ItemStackWrapper;
+
+public class SetMoveableFunction extends Function {
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 453447798953153174L;
+
+	public SetMoveableFunction(String name) 
+	{
+		super(name);
+	}
+
+	@Override
+	public boolean function(PlayerWrapper<?> playerWrapper) 
+	{
+		if(this.getOwner() instanceof Slot)
+		{
+			Boolean value = Boolean.valueOf(this.getData());
+			if(value != null)
+			{
+				FunctionOwner owner = this.getOwner();
+				if(owner != null)
+				{
+					if(owner instanceof Slot)
+					{
+						Slot slot = (Slot) owner;
+						Gui gui = slot.getOwner();
+						if(gui != null)
+						{
+							slot.setMoveable(value);
+							return true;
+						}
+					}
+				}
+			}
+		}
+		
+		return false;
+	}
+}

--- a/src/main/java/com/clubobsidian/dynamicgui/gui/Slot.java
+++ b/src/main/java/com/clubobsidian/dynamicgui/gui/Slot.java
@@ -116,6 +116,11 @@ public class Slot implements Serializable, FunctionOwner, AnimationHolder {
 		return this.moveable;
 	}
 	
+	public void setMoveable(boolean moveable)
+	{
+		this.moveable = moveable;
+	}
+	
 	public short getData()
 	{
 		return this.data;

--- a/src/main/java/com/clubobsidian/dynamicgui/gui/Slot.java
+++ b/src/main/java/com/clubobsidian/dynamicgui/gui/Slot.java
@@ -41,6 +41,7 @@ public class Slot implements Serializable, FunctionOwner, AnimationHolder {
 	private String nbt;
 	private short data;
 	private boolean glow;
+	private boolean moveable;
 
 	private List<String> lore;
 	private List<EnchantmentWrapper> enchants;
@@ -54,13 +55,14 @@ public class Slot implements Serializable, FunctionOwner, AnimationHolder {
 	private int frame;
 	private Map<String, String> metadata;
 	private boolean update;
-	public Slot(int index, int amount, String icon, String name, String nbt, short data, boolean glow, Boolean close, List<String> lore, List<EnchantmentWrapper> enchants, FunctionTree functions, int updateInterval, Map<String, String> metadata)
+	public Slot(int index, int amount, String icon, String name, String nbt, short data, boolean glow, boolean moveable, Boolean close, List<String> lore, List<EnchantmentWrapper> enchants, FunctionTree functions, int updateInterval, Map<String, String> metadata)
 	{
 		this.icon = icon;
 		this.data = data;
 		this.name = name;
 		this.nbt = nbt;
 		this.glow = glow;
+		this.moveable = moveable;
 		this.lore = lore;
 		this.enchants = enchants;
 		this.close = close;
@@ -107,6 +109,11 @@ public class Slot implements Serializable, FunctionOwner, AnimationHolder {
 	public boolean getGlow()
 	{
 		return this.glow;
+	}
+	
+	public boolean isMoveable()
+	{
+		return this.moveable;
 	}
 	
 	public short getData()

--- a/src/main/java/com/clubobsidian/dynamicgui/inventory/InventoryWrapper.java
+++ b/src/main/java/com/clubobsidian/dynamicgui/inventory/InventoryWrapper.java
@@ -37,15 +37,16 @@ public abstract class InventoryWrapper<T> implements Serializable {
 		return this.inventory;
 	}
 	
+	public abstract ItemStackWrapper<?>[] getContents();
 	public abstract ItemStackWrapper<?> getItem(int index);
 	public abstract void setItem(int index, ItemStackWrapper<?> itemStackWrapper);
 	public abstract void updateItem(int index, PlayerWrapper<?> playerWrapper);
 	public abstract int getSize();
-	public abstract int getContentSize();
+	public abstract int getCurrentContentSize();
 	
 	public int addItem(ItemStackWrapper<?> itemStackWrapper) 
 	{
-		int index = this.getContentSize();
+		int index = this.getCurrentContentSize();
 		if(index >= this.getSize())
 			return -1;
 		

--- a/src/main/java/com/clubobsidian/dynamicgui/inventory/ItemStackWrapper.java
+++ b/src/main/java/com/clubobsidian/dynamicgui/inventory/ItemStackWrapper.java
@@ -47,6 +47,8 @@ public abstract class ItemStackWrapper<T> implements Serializable {
 	public abstract int getAmount();
 	public abstract void setAmount(int amount);
 	
+	public abstract int getMaxStackSize();
+	
 	public abstract String getType();
 	public abstract boolean setType(String type);
 	
@@ -67,5 +69,7 @@ public abstract class ItemStackWrapper<T> implements Serializable {
 	public abstract void setNBT(String nbt);
 	
 	public abstract void setGlowing(boolean glowing);
+	
+	public abstract boolean isSimilar(ItemStackWrapper<?> compareTo);
 	
 }

--- a/src/main/java/com/clubobsidian/dynamicgui/inventory/bukkit/BukkitInventoryWrapper.java
+++ b/src/main/java/com/clubobsidian/dynamicgui/inventory/bukkit/BukkitInventoryWrapper.java
@@ -40,6 +40,21 @@ public class BukkitInventoryWrapper<T extends Inventory> extends InventoryWrappe
 	}
 
 	@Override
+	public ItemStackWrapper<?>[] getContents() 
+	{
+		ItemStack[] bukkitContents = this.getInventory().getContents();
+		ItemStackWrapper<?>[] wrapperContents = new ItemStackWrapper<?>[bukkitContents.length];
+		for(int i = 0; i < bukkitContents.length; i++)
+		{
+			ItemStack itemStack = bukkitContents[i];
+			ItemStackWrapper<?> wrapped = new BukkitItemStackWrapper<>(itemStack);
+			wrapperContents[i] = wrapped;
+		}
+		
+		return wrapperContents;
+	}
+	
+	@Override
 	public ItemStackWrapper<ItemStack> getItem(int index) 
 	{
 		return new BukkitItemStackWrapper<ItemStack>(this.getInventory().getItem(index));
@@ -67,7 +82,7 @@ public class BukkitInventoryWrapper<T extends Inventory> extends InventoryWrappe
 	}
 	
 	@Override
-	public int getContentSize() 
+	public int getCurrentContentSize() 
 	{
 		int contentSize = 0;
 		for(ItemStack item : this.getInventory().getContents())

--- a/src/main/java/com/clubobsidian/dynamicgui/inventory/bukkit/BukkitItemStackWrapper.java
+++ b/src/main/java/com/clubobsidian/dynamicgui/inventory/bukkit/BukkitItemStackWrapper.java
@@ -56,6 +56,12 @@ public class BukkitItemStackWrapper<T extends ItemStack> extends ItemStackWrappe
 	}
 	
 	@Override
+	public int getMaxStackSize() 
+	{
+		return this.getItemStack().getMaxStackSize();
+	}
+	
+	@Override
 	public String getType() 
 	{
 		return this.getItemStack().getType().toString();
@@ -233,5 +239,11 @@ public class BukkitItemStackWrapper<T extends ItemStack> extends ItemStackWrappe
 		}
 		
 		item.setItemMeta(meta);
+	}
+
+	@Override
+	public boolean isSimilar(ItemStackWrapper<?> compareTo) 
+	{
+		return this.getItemStack().isSimilar((ItemStack) compareTo.getItemStack());
 	}
 }

--- a/src/main/java/com/clubobsidian/dynamicgui/inventory/sponge/SpongeInventoryWrapper.java
+++ b/src/main/java/com/clubobsidian/dynamicgui/inventory/sponge/SpongeInventoryWrapper.java
@@ -43,6 +43,13 @@ public class SpongeInventoryWrapper<T extends Inventory> extends InventoryWrappe
 	}
 
 	@Override
+	public ItemStackWrapper<?>[] getContents() 
+	{
+		// TODO Auto-generated method stub
+		return null;
+	}
+	
+	@Override
 	public ItemStackWrapper<ItemStack> getItem(int index) 
 	{
 		int i = 0;
@@ -95,9 +102,8 @@ public class SpongeInventoryWrapper<T extends Inventory> extends InventoryWrappe
 	}
 	
 	@Override
-	public int getContentSize() 
+	public int getCurrentContentSize() 
 	{
 		return this.getInventory().size();
 	}
-
 }

--- a/src/main/java/com/clubobsidian/dynamicgui/inventory/sponge/SpongeItemStackWrapper.java
+++ b/src/main/java/com/clubobsidian/dynamicgui/inventory/sponge/SpongeItemStackWrapper.java
@@ -100,6 +100,12 @@ public class SpongeItemStackWrapper<T extends ItemStack> extends ItemStackWrappe
 	{
 		this.getItemStack().setQuantity(amount);
 	}
+	
+	@Override
+	public int getMaxStackSize() 
+	{
+		return this.getItemStack().getMaxStackQuantity();
+	}
 
 	@SuppressWarnings("deprecation")
 	@Override
@@ -268,5 +274,12 @@ public class SpongeItemStackWrapper<T extends ItemStack> extends ItemStackWrappe
 	{
 		// TODO Auto-generated method stub
 		
+	}
+
+	@Override
+	public boolean isSimilar(ItemStackWrapper<?> compareTo) 
+	{
+		// TODO Auto-generated method stub
+		return false;
 	}
 }

--- a/src/main/java/com/clubobsidian/dynamicgui/listener/InventoryClickListener.java
+++ b/src/main/java/com/clubobsidian/dynamicgui/listener/InventoryClickListener.java
@@ -39,26 +39,22 @@ public class InventoryClickListener {
 		{
 			return;
 		}
-		
-		if(!GuiManager.get().hasGuiCurrently(e.getPlayerWrapper()))
+		else if(!GuiManager.get().hasGuiCurrently(e.getPlayerWrapper()))
 		{
 			return;
 		}
 		
-		e.setCanceled(true);
 		
 		ItemStackWrapper<?> item = e.getItemStackWrapper();
 		if(item.getItemStack() == null)
 		{
 			return;
 		}
-		
-		if(e.getView() != InventoryView.TOP)
+		else if(e.getView() != InventoryView.TOP)
 		{
 			return;
 		}
-		
-		if(e.getClick() == null) //For other types of clicks besides left, right, middle
+		else if(e.getClick() == null) //For other types of clicks besides left, right, middle
 		{
 			return;
 		}
@@ -77,25 +73,42 @@ public class InventoryClickListener {
 		}
 
 		if(slot == null)
+		{
 			return;
+		}
+		
+		if(!slot.isMoveable())
+		{
+			e.setCanceled(true);
+		}
 
 		List<FunctionNode> functions = slot.getFunctions().getRootNodes();
 
 		if(functions.size() == 0)
+		{
 			return;
+		}
 
 		String clickString = e.getClick().toString();
 		FunctionUtil.tryFunctions(slot, FunctionType.valueOf(clickString), player);
 		
 		Boolean close = null;
 		if(slot.getClose() != null)
+		{
 			close = slot.getClose();
+		}
 		else if(gui.getClose() != null)
+		{
 			close = gui.getClose();
+		}
 		else
+		{
 			close = true;
+		}
 
 		if(close)
+		{
 			player.closeInventory();
+		}
 	}
 }

--- a/src/main/java/com/clubobsidian/dynamicgui/listener/InventoryInteractListener.java
+++ b/src/main/java/com/clubobsidian/dynamicgui/listener/InventoryInteractListener.java
@@ -79,14 +79,11 @@ public class InventoryInteractListener {
 
 		
 		List<FunctionNode> functions = slot.getFunctions().getRootNodes();
-
-		if(functions.size() == 0)
+		if(functions.size() > 0)
 		{
-			return;
+			String clickString = e.getClick().toString();
+			FunctionUtil.tryFunctions(slot, FunctionType.valueOf(clickString), player);
 		}
-
-		String clickString = e.getClick().toString();
-		FunctionUtil.tryFunctions(slot, FunctionType.valueOf(clickString), player);
 		
 		if(!slot.isMoveable())
 		{

--- a/src/main/java/com/clubobsidian/dynamicgui/listener/InventoryInteractListener.java
+++ b/src/main/java/com/clubobsidian/dynamicgui/listener/InventoryInteractListener.java
@@ -56,14 +56,15 @@ public class InventoryInteractListener {
 		}
 		
 		ItemStackWrapper<?> item = e.getItemStackWrapper();
-		if(item.getItemStack() == null)
+		if(e.getClick() == null) //For other types of clicks besides left, right, middle
 		{
+			e.setCanceled(true);
 			return;
 		}
-		else if(e.getClick() == null) //For other types of clicks besides left, right, middle
+		else if(item.getItemStack() == null)
 		{
 			return;
-		}
+		}	
 		else if(e.getView() == InventoryView.BOTTOM)
 		{
 			if(e.getClick() == Click.SHIFT_LEFT || e.getClick() == Click.SHIFT_RIGHT)

--- a/src/main/java/com/clubobsidian/dynamicgui/listener/bukkit/InventoryInteractListener.java
+++ b/src/main/java/com/clubobsidian/dynamicgui/listener/bukkit/InventoryInteractListener.java
@@ -70,7 +70,11 @@ public class InventoryInteractListener implements Listener {
 			InventoryWrapper<?> inventoryWrapper = new BukkitInventoryWrapper<Inventory>(inventory);
 			PlayerWrapper<?> playerWrapper = new BukkitPlayerWrapper<Player>(player);
 			ItemStack itemStack = null;
-			if(slot >= 0 && slot < inventory.getSize())
+			if(rawSlot >= inventory.getSize())
+			{
+				itemStack = e.getWhoClicked().getInventory().getItem(slot);
+			}
+			else if(slot >= 0 && slot < inventory.getSize())
 			{
 				itemStack = e.getInventory().getItem(slot);
 			}

--- a/src/main/java/com/clubobsidian/dynamicgui/listener/sponge/InventoryInteractListener.java
+++ b/src/main/java/com/clubobsidian/dynamicgui/listener/sponge/InventoryInteractListener.java
@@ -40,7 +40,7 @@ import com.clubobsidian.dynamicgui.inventory.ItemStackWrapper;
 import com.clubobsidian.dynamicgui.inventory.sponge.SpongeInventoryWrapper;
 import com.clubobsidian.dynamicgui.inventory.sponge.SpongeItemStackWrapper;
 
-public class InventoryClickListener {
+public class InventoryInteractListener {
 
 	@Listener
 	public void inventoryClick(ClickInventoryEvent e, @First Player player)

--- a/src/main/java/com/clubobsidian/dynamicgui/manager/dynamicgui/GuiManager.java
+++ b/src/main/java/com/clubobsidian/dynamicgui/manager/dynamicgui/GuiManager.java
@@ -146,6 +146,20 @@ public class GuiManager {
 		return this.playerGuis.get(playerWrapper.getUniqueId()) != null;
 	}
 	
+	public boolean hasGuiOpen(PlayerWrapper<?> playerWrapper)
+	{
+		if(playerWrapper.getOpenInventoryWrapper() == null)
+		{
+			return false;
+		}
+		else if(!this.hasGuiCurrently(playerWrapper))
+		{
+			return false;
+		}
+		
+		return true;
+	}
+	
 	public void cleanupGui(PlayerWrapper<?> playerWrapper)
 	{
 		this.playerGuis.remove(playerWrapper.getUniqueId());

--- a/src/main/java/com/clubobsidian/dynamicgui/manager/dynamicgui/GuiManager.java
+++ b/src/main/java/com/clubobsidian/dynamicgui/manager/dynamicgui/GuiManager.java
@@ -511,7 +511,7 @@ public class GuiManager {
 			short data = slotToken.getData();
 			
 			boolean glow = slotToken.getGlow();
-			boolean moveable = false; //TODO
+			boolean moveable = slotToken.isMoveable();
 			
 			int updateInterval = slotToken.getUpdateInterval();
 

--- a/src/main/java/com/clubobsidian/dynamicgui/manager/dynamicgui/GuiManager.java
+++ b/src/main/java/com/clubobsidian/dynamicgui/manager/dynamicgui/GuiManager.java
@@ -497,12 +497,13 @@ public class GuiManager {
 			short data = slotToken.getData();
 			
 			boolean glow = slotToken.getGlow();
+			boolean moveable = false; //TODO
 			
 			int updateInterval = slotToken.getUpdateInterval();
 
 			Map<String, String> metadata = slotToken.getMetadata();
 			
-			slots.add(new Slot(index, amount, icon, name, nbt, data, glow, close, lore, enchants, slotToken.getFunctionTree(), updateInterval, metadata));
+			slots.add(new Slot(index, amount, icon, name, nbt, data, glow, moveable, close, lore, enchants, slotToken.getFunctionTree(), updateInterval, metadata));
 		}
 
 		

--- a/src/main/java/com/clubobsidian/dynamicgui/plugin/bukkit/BukkitPlugin.java
+++ b/src/main/java/com/clubobsidian/dynamicgui/plugin/bukkit/BukkitPlugin.java
@@ -37,7 +37,7 @@ import com.clubobsidian.dynamicgui.economy.Economy;
 import com.clubobsidian.dynamicgui.economy.bukkit.VaultEconomy;
 import com.clubobsidian.dynamicgui.inject.module.PluginModule;
 import com.clubobsidian.dynamicgui.listener.bukkit.EntityClickListener;
-import com.clubobsidian.dynamicgui.listener.bukkit.InventoryClickListener;
+import com.clubobsidian.dynamicgui.listener.bukkit.InventoryInteractListener;
 import com.clubobsidian.dynamicgui.listener.bukkit.InventoryCloseListener;
 import com.clubobsidian.dynamicgui.listener.bukkit.InventoryOpenListener;
 import com.clubobsidian.dynamicgui.listener.bukkit.PlayerInteractListener;
@@ -119,7 +119,7 @@ public class BukkitPlugin extends JavaPlugin implements DynamicGuiPlugin {
 		this.getCommand("gui").setExecutor(new BukkitGuiCommand());
 		this.getCommand("dynamicgui").setExecutor(new BukkitDynamicGuiCommand());
 		Bukkit.getServer().getPluginManager().registerEvents(new EntityClickListener(), this);
-		Bukkit.getServer().getPluginManager().registerEvents(new InventoryClickListener(), this);
+		Bukkit.getServer().getPluginManager().registerEvents(new InventoryInteractListener(), this);
 		Bukkit.getServer().getPluginManager().registerEvents(new InventoryCloseListener(), this);
 		Bukkit.getServer().getPluginManager().registerEvents(new InventoryOpenListener(), this);
 		Bukkit.getServer().getPluginManager().registerEvents(new PlayerInteractListener(), this);

--- a/src/main/java/com/clubobsidian/dynamicgui/plugin/sponge/SpongePlugin.java
+++ b/src/main/java/com/clubobsidian/dynamicgui/plugin/sponge/SpongePlugin.java
@@ -21,7 +21,7 @@ import com.clubobsidian.dynamicgui.command.sponge.SpongeGuiCommand;
 import com.clubobsidian.dynamicgui.economy.Economy;
 import com.clubobsidian.dynamicgui.inject.module.PluginModule;
 import com.clubobsidian.dynamicgui.listener.sponge.EntityClickListener;
-import com.clubobsidian.dynamicgui.listener.sponge.InventoryClickListener;
+import com.clubobsidian.dynamicgui.listener.sponge.InventoryInteractListener;
 import com.clubobsidian.dynamicgui.listener.sponge.InventoryCloseListener;
 import com.clubobsidian.dynamicgui.listener.sponge.InventoryOpenListener;
 import com.clubobsidian.dynamicgui.listener.sponge.PlayerInteractListener;
@@ -120,7 +120,7 @@ public class SpongePlugin implements DynamicGuiPlugin {
 		Sponge.getGame().getCommandManager().register(this, dynamicGuiSpec, "dynamicgui", "dyngui");
 		
 		Sponge.getEventManager().registerListeners(this, new EntityClickListener());
-		Sponge.getEventManager().registerListeners(this, new InventoryClickListener());
+		Sponge.getEventManager().registerListeners(this, new InventoryInteractListener());
 		Sponge.getEventManager().registerListeners(this, new InventoryCloseListener());
 		Sponge.getEventManager().registerListeners(this, new InventoryOpenListener());
 		Sponge.getEventManager().registerListeners(this, new PlayerInteractListener());


### PR DESCRIPTION
Initial support of moveable slots, this support is going to be continued by #158 but that is a larger task that may require a major version bump. This version rewrote the way clicks are handled and fixed potential already existing bugs with dragging. Dragging before moveable slot support was implemented  was not accounted for and may potentially be why sometimes players state that they lost their items. As the rewrite of the inventory clicking was extensive this version may still have bugs but none that can be accounted for at the moment. Fixes #157 